### PR TITLE
Use child of start span option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/opentracing-contrib/go-stdlib
+module github.com/gruane-sq/go-stdlib
 
 go 1.14
 

--- a/nethttp/server.go
+++ b/nethttp/server.go
@@ -122,7 +122,7 @@ func MiddlewareFunc(tr opentracing.Tracer, h http.HandlerFunc, options ...MWOpti
 			return
 		}
 		ctx, _ := tr.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
-		sp := tr.StartSpan(opts.opNameFunc(r), ext.RPCServerOption(ctx))
+		sp := tr.StartSpan(opts.opNameFunc(r), ext.RPCServerOption(ctx), opentracing.ChildOf(ctx))
 		ext.HTTPMethod.Set(sp, r.Method)
 		ext.HTTPUrl.Set(sp, opts.urlTagFunc(r.URL))
 		ext.Component.Set(sp, componentName)


### PR DESCRIPTION
Extend client generated traces using data from the http headers.